### PR TITLE
Add option to display item names next to log command

### DIFF
--- a/src/main/java/com/runeprofile/RuneProfileConfig.java
+++ b/src/main/java/com/runeprofile/RuneProfileConfig.java
@@ -47,10 +47,21 @@ public interface RuneProfileConfig extends Config {
     }
 
     @ConfigItem(
+            keyName = "enableExtendedItemNames",
+            name = "Show item names for !log",
+            description = "Show item names next to their icons in the collection log command.",
+            position = 5
+    )
+    default boolean enableExtendedItemNames()
+    {
+        return false;
+    }
+
+    @ConfigItem(
             keyName = "show_clog_sync_button",
             name = "Enable RuneProfile Sync button",
             description = "Shows the RuneProfile button in the Collection Log menu.",
-            position = 5
+            position = 6
     )
     default boolean showClogSyncButton() {
         return true;
@@ -60,7 +71,7 @@ public interface RuneProfileConfig extends Config {
             keyName = "menu_lookup_option",
             name = "Chat menu option",
             description = "Add RuneProfile option to chat menus",
-            position = 6
+            position = 7
     )
     default boolean showMenuLookupOption() {
         return false;

--- a/src/main/java/com/runeprofile/ui/CollectionLogCommand.java
+++ b/src/main/java/com/runeprofile/ui/CollectionLogCommand.java
@@ -113,7 +113,13 @@ public class CollectionLogCommand {
                 for (CollectionLogItem item : items) {
                     if (item.getQuantity() < 1) continue;
 
+                    String itemName = itemManager.getItemComposition(item.getId()).getName();
                     String itemString = "<img=" + loadedItemIcons.get(item.getId()) + ">";
+
+                    if (config.enableExtendedItemNames()) {
+                        itemString += " " + itemName + " ";
+                    }
+
                     if (item.getQuantity() > 1) {
                         itemString += "x" + item.getQuantity();
                     }


### PR DESCRIPTION
Adds option to display collection log item names next to their sprite in the !log command, useful for sprites that aren't very obvious ie. prayer scrolls

<img width="603" height="73" alt="image" src="https://github.com/user-attachments/assets/6c71d044-cb41-4b2b-b523-89a08e4cec67" />
<img width="259" height="76" alt="image" src="https://github.com/user-attachments/assets/4e5bb01e-d171-4b48-a316-46c52185d7a0" />
