### PR TITLE
Use setRuneLiteFormatMessage to avoid other plugins overriding the message

### DIFF
--- a/src/main/java/com/runeprofile/ui/CollectionLogCommand.java
+++ b/src/main/java/com/runeprofile/ui/CollectionLogCommand.java
@@ -162,7 +162,7 @@ public class CollectionLogCommand {
     }
 
     private void updateChatMessage(ChatMessage chatMessage, String message) {
-        chatMessage.getMessageNode().setValue(message);
+        chatMessage.getMessageNode().setRuneLiteFormatMessage(message);
         client.runScript(ScriptID.BUILD_CHATBOX);
     }
 }


### PR DESCRIPTION
Bad, frowny face: 

https://github.com/user-attachments/assets/6462e241-46e5-44c5-a547-23a00cd0496d

Good, happy face: 

https://github.com/user-attachments/assets/8bdb8f96-73c2-4ee5-9a14-e687422e0213

